### PR TITLE
fix: Don't overwrite symlinks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "normpath"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf23ab2b905654b4cb177e30b629937b3868311d4e1cba859f899c041046e69b"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,6 +1406,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,6 +1436,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1555,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "wrkn"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "assert_cmd",
  "assert_fs",
@@ -1569,6 +1593,7 @@ dependencies = [
  "fake",
  "itertools",
  "nom",
+ "normpath",
  "once_cell",
  "owo-colors 4.2.0",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wrkn"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = ["Joseph Cooper"]
 license = "MIT"
@@ -19,6 +19,7 @@ directories = "6.0.0"
 edit = "0.1.4"
 itertools = "0.14.0"
 nom = "8.0.0"
+normpath = "1.5.0"
 once_cell = "1.18.0"
 owo-colors = { version = "4.2.0", features = ["supports-colors"] }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,13 +1,21 @@
 use crate::wrkn::{sort_entries_by_timestamp_reverse, Entry};
 use atomicwrites::{AtomicFile, OverwriteBehavior};
 use color_eyre::eyre;
+use normpath::PathExt;
 use std::fs::File;
 use std::io;
 use std::io::{BufRead, Write};
 use std::path::Path;
 
 pub fn save_wrkn_file<P: AsRef<Path>>(path: P, data: &mut [Entry]) -> eyre::Result<()> {
-    let af = AtomicFile::new(&path, OverwriteBehavior::AllowOverwrite);
+    let canonical_path = if path.as_ref().exists() {
+        let path_buf = path.as_ref().normalize()?;
+        path_buf.into_path_buf()
+    } else {
+        path.as_ref().to_path_buf()
+    };
+
+    let af = AtomicFile::new(&canonical_path, OverwriteBehavior::AllowOverwrite);
     af.write(|f| {
         data.sort_by_key(sort_entries_by_timestamp_reverse);
         for entry in data {


### PR DESCRIPTION
Since a3527b8c, wrkn writes files atomically. This had the side effect of
overwriting symlinks, rather than writing through them.

This change adds an integration test to demonstrate the buggy behaviour and
alters file writes so symlinks are canonicalized before writing atomically
to the symlink's target.

Closes #3
